### PR TITLE
chore: use greater than for npm engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   },
   "main": "dist/MaterialColorPicker.js",
   "engines": {
-    "npm": "^3.0.0"
+    "npm": ">=3.0.0"
   }
 }


### PR DESCRIPTION
Using a caret means that it wants npm 3 and not greater than npm 3.

This will get rid of a npm warning: 
```
npm WARN notsup Unsupported engine for @usulpro/color-picker@1.1.3: 
wanted: {"npm":"^3.0.0"} 
current: {"npm":"6.13.4"}
```